### PR TITLE
fix(ci): bump Python to 3.14

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -40,7 +40,7 @@ jobs:
       - name: "Set up Python"
         uses: actions/setup-python@v6.2.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: "pip"
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libturbojpeg0-dev

--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -13,7 +13,6 @@ from collections.abc import Callable
 from typing import Any
 
 import aiohttp
-import async_timeout
 
 from .digest import DigestAuth
 from hashlib import md5
@@ -990,7 +989,7 @@ class DahuaClient:
         url = (
             "{0}/cgi-bin/audio.cgi?action=getAudio&httptype=singlepart&channel={1}"
         ).format(self._base, channel)
-        async with async_timeout.timeout(TIMEOUT_SECONDS):
+        async with asyncio.timeout(TIMEOUT_SECONDS):
             auth = DigestAuth(self._username, self._password, self._session)
             response = await auth.request("GET", url)
             response.raise_for_status()
@@ -1027,7 +1026,7 @@ class DahuaClient:
         # Prime digest auth with a lightweight GET so the POST is
         # authenticated on first attempt (camera drops un-authed POSTs).
         prime_auth = DigestAuth(self._username, self._password, self._session)
-        async with async_timeout.timeout(TIMEOUT_SECONDS):
+        async with asyncio.timeout(TIMEOUT_SECONDS):
             prime_resp = await prime_auth.request(
                 "GET", self._base + "/cgi-bin/magicBox.cgi?action=getMachineName"
             )
@@ -1080,7 +1079,7 @@ class DahuaClient:
 
         response = None
         try:
-            async with async_timeout.timeout(duration + 10):
+            async with asyncio.timeout(duration + 10):
                 response = await auth.request("POST", url, headers=headers, data=body)
         except asyncio.TimeoutError:
             # Expected for cameras that treat this as a streaming endpoint
@@ -1318,7 +1317,7 @@ class DahuaClient:
 
     async def get_bytes(self, url: str) -> bytes:
         """Get information from the API. This will return the raw response and not process it"""
-        async with async_timeout.timeout(TIMEOUT_SECONDS):
+        async with asyncio.timeout(TIMEOUT_SECONDS):
             response = None
             try:
                 auth = DigestAuth(self._username, self._password, self._session)
@@ -1335,7 +1334,7 @@ class DahuaClient:
         """Get information from the API."""
         url = self._base + url
         try:
-            async with async_timeout.timeout(TIMEOUT_SECONDS):
+            async with asyncio.timeout(TIMEOUT_SECONDS):
                 response = None
                 try:
                     auth = DigestAuth(self._username, self._password, self._session)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.mypy]
-python_version = "3.13"
+python_version = "3.14"
 strict = true
 warn_return_any = true
 warn_unused_configs = true

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,3 @@
-pytest-homeassistant-custom-component==0.13.286
+pytest-homeassistant-custom-component==0.13.323
 pycares>=4.0.0,<5.0.0
 PyTurboJPEG>=1.6.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,3 @@
 pytest-homeassistant-custom-component==0.13.323
-pycares>=4.0.0,<5.0.0
+pycares>=5.0.0
 PyTurboJPEG>=1.6.0

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -38,9 +38,12 @@ MOCK_DEVICE_DATA = {
 
 async def test_user_flow_success(hass: HomeAssistant):
     """Test a successful config flow from the user step through the name step."""
-    with patch(
-        "custom_components.dahua.config_flow.DahuaFlowHandler._test_credentials",
-        return_value=MOCK_DEVICE_DATA,
+    with (
+        patch(
+            "custom_components.dahua.config_flow.DahuaFlowHandler._test_credentials",
+            return_value=MOCK_DEVICE_DATA,
+        ),
+        patch("custom_components.dahua.async_setup_entry", return_value=True),
     ):
         # Step 1: show user form
         result = await hass.config_entries.flow.async_init(
@@ -217,9 +220,12 @@ async def test_user_flow_with_channel_gt_0(hass: HomeAssistant):
     """Test config flow with channel > 0 appends channel to unique_id."""
     input_with_channel = {**MOCK_USER_INPUT, CONF_CHANNEL: 1}
 
-    with patch(
-        "custom_components.dahua.config_flow.DahuaFlowHandler._test_credentials",
-        return_value=MOCK_DEVICE_DATA,
+    with (
+        patch(
+            "custom_components.dahua.config_flow.DahuaFlowHandler._test_credentials",
+            return_value=MOCK_DEVICE_DATA,
+        ),
+        patch("custom_components.dahua.async_setup_entry", return_value=True),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -249,9 +255,13 @@ async def test_reconfigure_flow_success(hass: HomeAssistant):
     )
     entry.add_to_hass(hass)
 
-    with patch(
-        "custom_components.dahua.config_flow.DahuaFlowHandler._test_credentials",
-        return_value=MOCK_DEVICE_DATA,
+    with (
+        patch(
+            "custom_components.dahua.config_flow.DahuaFlowHandler._test_credentials",
+            return_value=MOCK_DEVICE_DATA,
+        ),
+        patch("custom_components.dahua.async_setup_entry", return_value=True),
+        patch("custom_components.dahua.async_unload_entry", return_value=True),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,


### PR DESCRIPTION
## Summary
- `pytest-homeassistant-custom-component` 0.13.317+ requires Python ≥3.14 because Home Assistant 2026.3.1+ does.
- CI was pinned to 3.13, which is why #43 (bump to 0.13.323) fails to install.
- Bumps CI Python to 3.14 in [.github/workflows/pull.yml](../blob/main/.github/workflows/pull.yml) and the mypy pin in [pyproject.toml](../blob/main/pyproject.toml) for consistency.

## Unblocks
- #43 (Renovate: pytest-homeassistant-custom-component 0.13.323) — rebase after merge.

## Test plan
- [ ] CI tests pass on this PR on Python 3.14.
- [ ] After merge, rebase #43 (check the rebase box in its body) and confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Python target from 3.13 to 3.14 in CI and type-checker configuration.
  * Updated test dependencies to newer releases to match the Python update.
  * Replaced an external timeout dependency with the Python standard library timeout, reducing third-party dependency usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->