### PR TITLE
chore(renovate): pin pycares to <5.0.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["pycares"],
+      "allowedVersions": "<5.0.0",
+      "description": "pycares 5.x removed ares_query_a_result which Home Assistant still uses. Revisit once upstream HA adapts."
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a Renovate packageRule pinning \`pycares\` to \`<5.0.0\`.
- Context: #44 was closed because \`pycares 5.0.1\` removed \`ares_query_a_result\` which Home Assistant still calls. Without this rule Renovate will keep reopening the bump PR on every pycares release.

## Test plan
- [ ] Renovate picks up the new config on next run and does not recreate the pycares v5 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)