### PR TITLE
ci(release-please): use RELEASE_PLEASE_TOKEN PAT

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,9 @@ jobs:
       - id: release
         uses: googleapis/release-please-action@v4
         with:
+          # Fine-grained PAT so the release PR triggers other workflows
+          # (GITHUB_TOKEN-authored PRs are blocked from triggering Actions).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
@@ -29,7 +32,7 @@ jobs:
       - name: Enable auto-merge on release PR (daily)
         if: github.event_name == 'schedule' && steps.release.outputs.pr != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           PR_JSON: ${{ steps.release.outputs.pr }}
         run: |
           PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')


### PR DESCRIPTION
## Summary
- Switches release-please (and its \`gh pr merge --auto\` call) from \`GITHUB_TOKEN\` to a fine-grained PAT stored as \`RELEASE_PLEASE_TOKEN\`.
- Reason: PRs opened by \`GITHUB_TOKEN\` don't trigger other workflows. Observed on #49 / #51 — \"Pull actions\" stuck without running, so required status checks can't gate the release and auto-merge has nothing to wait on.
- This commit was pushed to the #47 branch after #47 was squash-merged, so it got stranded. Cherry-picked onto a fresh branch.

## Test plan
- [ ] Merge this PR.
- [ ] Close #51, re-dispatch \`release-please.yml\`, confirm the regenerated release PR is authored by the PAT user (not \`github-actions[bot]\`) and Pull actions runs on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)